### PR TITLE
Add per-table settings for server administrators

### DIFF
--- a/src/main/java/com/vortex/blackjack/BlackjackPlugin.java
+++ b/src/main/java/com/vortex/blackjack/BlackjackPlugin.java
@@ -8,6 +8,7 @@ import com.vortex.blackjack.integration.BlackjackPlaceholderExpansion;
 import com.vortex.blackjack.model.PlayerStats;
 import com.vortex.blackjack.table.BlackjackTable;
 import com.vortex.blackjack.table.TableManager;
+import com.vortex.blackjack.table.TableSettings;
 import com.vortex.blackjack.util.AsyncUtils;
 import com.vortex.blackjack.util.GenericUtils;
 import com.vortex.blackjack.util.VersionChecker;
@@ -186,10 +187,17 @@ public class BlackjackPlugin extends JavaPlugin implements Listener {
             
             // Table management
             messagesConfig.set("table-created", "&aBlackjack table created!");
+            messagesConfig.set("table-created-with-settings", "&aTable created! &7(min: &e%min_bet%&7, max: &e%max_bet%&7, players: &e%max_players%&7, distance: &e%max_join_distance%&7)");
+            messagesConfig.set("createtable-invalid-arg", "&cInvalid argument: %error%");
             messagesConfig.set("table-removed", "&cBlackjack table removed!");
             messagesConfig.set("table-already-exists", "&cTable already exists at this location!");
             messagesConfig.set("table-remove-failed", "&cFailed to remove table!");
             messagesConfig.set("no-table-nearby", "&cNo table found nearby!");
+            messagesConfig.set("settable-usage", "&eUsage: /bj settable <setting> <value>");
+            messagesConfig.set("settable-unknown-setting", "&cUnknown setting '%setting%'. Valid: min-bet, max-bet, max-players, max-join-distance");
+            messagesConfig.set("settable-invalid-value", "&cInvalid value: '%value%'");
+            messagesConfig.set("settable-validation-error", "&cValidation failed: %error%");
+            messagesConfig.set("settable-updated", "&aSetting &e%setting% &aset to &e%value% &aon nearest table.");
             
             // Player table status
             messagesConfig.set("already-at-table", "&cYou are already at a table! Use /leave to leave your current table.");
@@ -276,7 +284,8 @@ public class BlackjackPlugin extends JavaPlugin implements Listener {
             
             // Help command
             messagesConfig.set("help-header", "&rAvailable Commands:");
-            messagesConfig.set("help-admin-create", "&e/bj createtable &7- Create a new blackjack table");
+            messagesConfig.set("help-admin-create", "&e/bj createtable [min-bet:<n>] [max-bet:<n>] [max-players:<n>] [max-join-distance:<n>] &7- Create a table");
+            messagesConfig.set("help-admin-settable", "&e/bj settable <setting> <value> &7- Modify nearest table settings");
             messagesConfig.set("help-admin-remove", "&e/bj removetable &7- Remove the nearest table");
             messagesConfig.set("help-admin-reload", "&e/bj reload &7- Reload configuration");
             messagesConfig.set("help-join", "&e/join &7- Join the nearest table");
@@ -405,7 +414,7 @@ public class BlackjackPlugin extends JavaPlugin implements Listener {
             BlackjackTable table = tableManager.getPlayerTable(player);
             if (table != null) {
                 double distance = player.getLocation().distance(table.getCenterLocation());
-                double maxDistance = configManager.getMaxJoinDistance();
+                double maxDistance = table.getSettings().getMaxJoinDistance(configManager);
                 
                 if (distance > maxDistance) {
                     // Player moved too far from table, auto-leave
@@ -433,7 +442,8 @@ public class BlackjackPlugin extends JavaPlugin implements Listener {
         String action = args[0].toLowerCase();
         
         return switch (action) {
-            case "createtable" -> handleCreateTable(player);
+            case "createtable" -> handleCreateTable(player, args);
+            case "settable" -> handleSetTable(player, args);
             case "removetable" -> handleRemoveTable(player);
             case "join" -> handleJoin(player);
             case "leave" -> handleLeave(player);
@@ -453,18 +463,90 @@ public class BlackjackPlugin extends JavaPlugin implements Listener {
     
     // Command handlers - clean and focused methods
     
-    private boolean handleCreateTable(Player player) {
+    private boolean handleCreateTable(Player player, String[] args) {
         if (!player.hasPermission("blackjack.admin")) {
             player.sendMessage(configManager.getMessage("no-permission"));
             return true;
         }
-        
-        if (tableManager.createTable(player.getLocation())) {
-            player.sendMessage(configManager.getMessage("table-created"));
+
+        StringBuilder err = new StringBuilder();
+        TableSettings settings = TableSettings.parseArgs(args, 1, configManager, err);
+        if (settings == null) {
+            player.sendMessage(configManager.formatMessage("createtable-invalid-arg", "error", err.toString()));
+            return true;
+        }
+
+        if (tableManager.createTable(player.getLocation(), settings)) {
+            player.sendMessage(configManager.formatMessage("table-created-with-settings",
+                "min_bet",          settings.getMinBet(configManager),
+                "max_bet",          settings.getMaxBet(configManager),
+                "max_players",      settings.getMaxPlayers(configManager),
+                "max_join_distance", settings.getMaxJoinDistance(configManager)));
         } else {
             player.sendMessage(configManager.getMessage("table-already-exists"));
         }
         return true;
+    }
+
+    private boolean handleSetTable(Player player, String[] args) {
+        if (!player.hasPermission("blackjack.admin")) {
+            player.sendMessage(configManager.getMessage("no-permission"));
+            return true;
+        }
+
+        // /bj settable <setting> <value>
+        if (args.length < 3) {
+            player.sendMessage(configManager.getMessage("settable-usage"));
+            return true;
+        }
+
+        BlackjackTable table = tableManager.findNearestTable(player.getLocation());
+        if (table == null) {
+            player.sendMessage(configManager.getMessage("no-table-nearby"));
+            return true;
+        }
+
+        String setting = args[1].toLowerCase();
+        String value   = args[2];
+        TableSettings s = table.getSettings();
+
+        try {
+            switch (setting) {
+                case "min-bet"            -> s.setMinBet(parsePositiveInt(value));
+                case "max-bet"            -> s.setMaxBet(parsePositiveInt(value));
+                case "max-players"        -> s.setMaxPlayers(Math.max(1, Math.min(8, parsePositiveInt(value))));
+                case "max-join-distance"  -> s.setMaxJoinDistance(parsePositiveDouble(value));
+                default -> {
+                    player.sendMessage(configManager.formatMessage("settable-unknown-setting", "setting", setting));
+                    return true;
+                }
+            }
+        } catch (NumberFormatException e) {
+            player.sendMessage(configManager.formatMessage("settable-invalid-value", "value", value));
+            return true;
+        }
+
+        String err = s.validate(configManager);
+        if (err != null) {
+            player.sendMessage(configManager.formatMessage("settable-validation-error", "error", err));
+            return true;
+        }
+
+        tableManager.saveTableSettings(table);
+        player.sendMessage(configManager.formatMessage("settable-updated", "setting", setting, "value", value));
+        return true;
+    }
+
+    private int parsePositiveInt(String s) {
+        int v = Integer.parseInt(s);
+        if (v <= 0) throw new NumberFormatException("must be positive");
+        return v;
+    }
+
+    private double parsePositiveDouble(String s) {
+        double v = Double.parseDouble(s);
+        if (v <= 0) throw new NumberFormatException("must be positive");
+        return v;
     }
     
     private boolean handleRemoveTable(Player player) {
@@ -653,10 +735,17 @@ public class BlackjackPlugin extends JavaPlugin implements Listener {
     // Betting system - improved and thread-safe
     
     private boolean processBet(Player player, int amount) {
+        // Resolve per-table bet limits (fall back to global config if not at a table)
+        BlackjackTable playerTable = tableManager.getPlayerTable(player);
+        int effectiveMin = playerTable != null
+                ? playerTable.getSettings().getMinBet(configManager) : configManager.getMinBet();
+        int effectiveMax = playerTable != null
+                ? playerTable.getSettings().getMaxBet(configManager) : configManager.getMaxBet();
+
         // Validate bet amount
-        if (amount < configManager.getMinBet() || amount > configManager.getMaxBet()) {
-            player.sendMessage(configManager.formatMessage("invalid-bet", 
-                "min_bet", configManager.getMinBet(), "max_bet", configManager.getMaxBet()));
+        if (amount < effectiveMin || amount > effectiveMax) {
+            player.sendMessage(configManager.formatMessage("invalid-bet",
+                "min_bet", effectiveMin, "max_bet", effectiveMax));
             return true;
         }
         
@@ -764,6 +853,7 @@ public class BlackjackPlugin extends JavaPlugin implements Listener {
         
         if (player.hasPermission("blackjack.admin")) {
             player.sendMessage(configManager.getMessage("help-admin-create"));
+            player.sendMessage(configManager.getMessage("help-admin-settable"));
             player.sendMessage(configManager.getMessage("help-admin-remove"));
             player.sendMessage(configManager.getMessage("help-admin-reload"));
         }

--- a/src/main/java/com/vortex/blackjack/commands/CommandManager.java
+++ b/src/main/java/com/vortex/blackjack/commands/CommandManager.java
@@ -34,8 +34,9 @@ public class CommandManager {
         registerCommand("stats", new StatsCommand(plugin));
         
         // Admin commands
-        registerCommand("createtable", new SimpleForwardCommand(plugin, "createtable"));
+        registerCommand("createtable", new CreateTableCommand(plugin));
         registerCommand("removetable", new SimpleForwardCommand(plugin, "removetable"));
+        registerCommand("settable", new SettableCommand(plugin));
         registerCommand("bjversion", new VersionCommand(plugin, plugin.getVersionChecker()));
     }
     

--- a/src/main/java/com/vortex/blackjack/commands/CreateTableCommand.java
+++ b/src/main/java/com/vortex/blackjack/commands/CreateTableCommand.java
@@ -1,0 +1,70 @@
+package com.vortex.blackjack.commands;
+
+import com.vortex.blackjack.BlackjackPlugin;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Handles /createtable with tab completion for per-table settings.
+ */
+public class CreateTableCommand extends BlackjackCommand {
+
+    private static final List<String> SETTING_KEYS = Arrays.asList(
+            "min-bet:", "max-bet:", "max-players:", "max-join-distance:"
+    );
+
+    private final BlackjackPlugin plugin;
+
+    public CreateTableCommand(BlackjackPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!isPlayer(sender)) {
+            sendPlayerOnlyMessage(sender);
+            return true;
+        }
+
+        // Prepend "createtable" and forward to main plugin
+        String[] newArgs = new String[args.length + 1];
+        newArgs[0] = "createtable";
+        System.arraycopy(args, 0, newArgs, 1, args.length);
+
+        return plugin.onCommand(sender, command, label, newArgs);
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (!(sender instanceof Player player) || !player.hasPermission("blackjack.admin")) {
+            return List.of();
+        }
+
+        // Collect which setting keys have already been typed
+        List<String> alreadyUsed = new ArrayList<>();
+        for (int i = 0; i < args.length - 1; i++) {
+            int colon = args[i].indexOf(':');
+            if (colon > 0) {
+                alreadyUsed.add(args[i].substring(0, colon) + ":");
+            }
+        }
+
+        // Current partial token
+        String partial = args[args.length - 1];
+
+        // Suggest setting keys that haven't been used yet
+        List<String> suggestions = new ArrayList<>();
+        for (String key : SETTING_KEYS) {
+            if (!alreadyUsed.contains(key)) {
+                suggestions.add(key);
+            }
+        }
+
+        return filterCompletions(suggestions, partial);
+    }
+}

--- a/src/main/java/com/vortex/blackjack/commands/SettableCommand.java
+++ b/src/main/java/com/vortex/blackjack/commands/SettableCommand.java
@@ -1,0 +1,81 @@
+package com.vortex.blackjack.commands;
+
+import com.vortex.blackjack.BlackjackPlugin;
+import com.vortex.blackjack.table.BlackjackTable;
+import com.vortex.blackjack.table.TableSettings;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Handles /settable with tab completion for setting names and current values.
+ */
+public class SettableCommand extends BlackjackCommand {
+
+    private static final List<String> SETTINGS = Arrays.asList(
+            "min-bet", "max-bet", "max-players", "max-join-distance"
+    );
+
+    private final BlackjackPlugin plugin;
+
+    public SettableCommand(BlackjackPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!isPlayer(sender)) {
+            sendPlayerOnlyMessage(sender);
+            return true;
+        }
+
+        // Prepend "settable" and forward to main plugin
+        String[] newArgs = new String[args.length + 1];
+        newArgs[0] = "settable";
+        System.arraycopy(args, 0, newArgs, 1, args.length);
+
+        return plugin.onCommand(sender, command, label, newArgs);
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (!(sender instanceof Player player) || !player.hasPermission("blackjack.admin")) {
+            return List.of();
+        }
+
+        if (args.length == 1) {
+            // Suggest setting names
+            return filterCompletions(SETTINGS, args[0]);
+        }
+
+        if (args.length == 2) {
+            // Suggest the current value for the nearest table as a hint
+            String setting = args[0].toLowerCase();
+            String currentValue = getCurrentValue(player, setting);
+            if (currentValue != null) {
+                return filterCompletions(List.of(currentValue), args[1]);
+            }
+        }
+
+        return List.of();
+    }
+
+    /** Returns the current (resolved) value for the given setting on the player's nearest table, or null. */
+    private String getCurrentValue(Player player, String setting) {
+        BlackjackTable table = plugin.getTableManager().findNearestTable(player.getLocation());
+        if (table == null) return null;
+
+        TableSettings s = table.getSettings();
+        var cfg = plugin.getConfigManager();
+        return switch (setting) {
+            case "min-bet"           -> String.valueOf(s.getMinBet(cfg));
+            case "max-bet"           -> String.valueOf(s.getMaxBet(cfg));
+            case "max-players"       -> String.valueOf(s.getMaxPlayers(cfg));
+            case "max-join-distance" -> String.valueOf(s.getMaxJoinDistance(cfg));
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/com/vortex/blackjack/table/BlackjackTable.java
+++ b/src/main/java/com/vortex/blackjack/table/BlackjackTable.java
@@ -40,6 +40,7 @@ public class BlackjackTable {
     private final ChatUtils chatUtils;
     private final BlackjackEngine gameEngine;
     private final Location centerLoc;
+    private final TableSettings settings;
     
     // Game state
     private final List<Player> players = new ArrayList<>();
@@ -61,13 +62,20 @@ public class BlackjackTable {
     private final Map<Player, Long> gameEndTimes = new ConcurrentHashMap<>();
     private BukkitTask autoLeaveTask;
     
-    public BlackjackTable(BlackjackPlugin plugin, TableManager tableManager, ConfigManager configManager, Location centerLoc) {
+    public BlackjackTable(BlackjackPlugin plugin, TableManager tableManager,
+                          ConfigManager configManager, Location centerLoc,
+                          TableSettings settings) {
         this.plugin = plugin;
         this.tableManager = tableManager;
         this.configManager = configManager;
         this.chatUtils = new ChatUtils(configManager);
         this.gameEngine = new BlackjackEngine();
         this.centerLoc = centerLoc;
+        this.settings = settings;
+    }
+
+    public TableSettings getSettings() {
+        return settings;
     }
     
     /**
@@ -85,7 +93,7 @@ public class BlackjackTable {
                 return false;
             }
             
-            if (players.size() >= configManager.getMaxPlayers()) {
+            if (players.size() >= settings.getMaxPlayers(configManager)) {
                 player.sendMessage(configManager.getMessage("table-full"));
                 return false;
             }
@@ -95,7 +103,7 @@ public class BlackjackTable {
                 return false;
             }
             
-            if (player.getLocation().distance(centerLoc) > configManager.getMaxJoinDistance()) {
+            if (player.getLocation().distance(centerLoc) > settings.getMaxJoinDistance(configManager)) {
                 player.sendMessage(configManager.getMessage("too-far"));
                 return false;
             }

--- a/src/main/java/com/vortex/blackjack/table/TableManager.java
+++ b/src/main/java/com/vortex/blackjack/table/TableManager.java
@@ -23,12 +23,12 @@ public class TableManager {
     private final ConfigManager configManager;
     private final Map<Location, BlackjackTable> tables = new ConcurrentHashMap<>();
     private final Map<Player, BlackjackTable> playerTables = new ConcurrentHashMap<>();
-    
+
     public TableManager(BlackjackPlugin plugin, ConfigManager configManager) {
         this.plugin = plugin;
         this.configManager = configManager;
     }
-    
+
     /**
      * Load tables from configuration on startup
      */
@@ -36,63 +36,71 @@ public class TableManager {
         if (!plugin.getConfig().contains("tables")) {
             return;
         }
-        
+
         for (String worldName : plugin.getConfig().getConfigurationSection("tables").getKeys(false)) {
             World world = Bukkit.getWorld(worldName);
             if (world == null) {
                 plugin.getLogger().warning("World not found: " + worldName);
                 continue;
             }
-            
+
             ConfigurationSection worldSection = plugin.getConfig().getConfigurationSection("tables." + worldName);
             for (String locString : worldSection.getKeys(false)) {
                 try {
                     String[] parts = locString.split("_");
                     if (parts.length != 3) continue;
-                    
+
                     int x = Integer.parseInt(parts[0]);
                     int y = Integer.parseInt(parts[1]);
                     int z = Integer.parseInt(parts[2]);
-                    
+
+                    TableSettings settings = loadSettingsFromConfig(worldSection, locString);
                     Location loc = new Location(world, x, y, z);
-                    createTable(loc, false); // Don't save to config again
+                    createTable(loc, settings, false); // Don't save to config again
                 } catch (NumberFormatException e) {
                     plugin.getLogger().warning("Invalid table location format: " + locString);
                 }
             }
         }
-        
+
         plugin.getLogger().info("Loaded " + tables.size() + " blackjack tables");
     }
-    
+
     /**
-     * Create a new blackjack table at the specified location
+     * Create a new blackjack table at the specified location using global default settings.
      */
     public boolean createTable(Location centerLoc) {
-        return createTable(centerLoc, true);
+        return createTable(centerLoc, new TableSettings(), true);
     }
-    
-    private boolean createTable(Location centerLoc, boolean saveToConfig) {
+
+    /**
+     * Create a new blackjack table at the specified location with per-table settings.
+     */
+    public boolean createTable(Location centerLoc, TableSettings settings) {
+        return createTable(centerLoc, settings, true);
+    }
+
+    private boolean createTable(Location centerLoc, TableSettings settings, boolean saveToConfig) {
         // Check if table already exists at this location
         for (Location loc : tables.keySet()) {
             if (loc.equals(centerLoc)) {
                 return false; // Table already exists
             }
         }
-        
+
         World world = centerLoc.getWorld();
         if (world == null) return false;
-        
+
         int centerX = centerLoc.getBlockX();
         int centerY = centerLoc.getBlockY();
         int centerZ = centerLoc.getBlockZ();
-        
+
         // Ensure chunk is loaded
         world.getChunkAt(centerLoc).load();
-        
+
         Material tableMaterial = configManager.getTableMaterial();
         Material chairMaterial = configManager.getChairMaterial();
-        
+
         // Create table blocks (3x3 hollow square)
         for (int x = -1; x <= 1; x++) {
             for (int z = -1; z <= 1; z++) {
@@ -102,27 +110,25 @@ public class TableManager {
                 }
             }
         }
-        
+
         // Place chairs at cardinal directions
         placeStair(world, centerX + 2, centerY, centerZ, BlockFace.EAST, chairMaterial);
         placeStair(world, centerX - 2, centerY, centerZ, BlockFace.WEST, chairMaterial);
         placeStair(world, centerX, centerY, centerZ + 2, BlockFace.SOUTH, chairMaterial);
         placeStair(world, centerX, centerY, centerZ - 2, BlockFace.NORTH, chairMaterial);
-        
+
         // Save to config if requested
         if (saveToConfig) {
-            String tablePath = "tables." + world.getName() + "." + centerX + "_" + centerY + "_" + centerZ;
-            plugin.getConfig().set(tablePath, true);
-            plugin.saveConfig();
+            saveTableToConfig(centerLoc, settings);
         }
-        
+
         // Create table object
-        BlackjackTable table = new BlackjackTable(plugin, this, configManager, centerLoc);
+        BlackjackTable table = new BlackjackTable(plugin, this, configManager, centerLoc, settings);
         tables.put(centerLoc, table);
-        
+
         return true;
     }
-    
+
     private void placeStair(World world, int x, int y, int z, BlockFace facing, Material material) {
         Block block = world.getBlockAt(x, y, z);
         block.setType(material);
@@ -131,65 +137,68 @@ public class TableManager {
             block.setBlockData(stairs);
         }
     }
-    
+
     /**
      * Remove a table at the specified location
      */
     public boolean removeTable(Location tableLoc) {
         BlackjackTable table = tables.remove(tableLoc);
         if (table == null) return false;
-        
+
         // Remove all players from the table
         table.removeAllPlayers();
         table.cleanup();
-        
+
         // Remove from config
         String worldName = tableLoc.getWorld().getName();
         int centerX = tableLoc.getBlockX();
         int centerY = tableLoc.getBlockY();
         int centerZ = tableLoc.getBlockZ();
-        
+
         if (plugin.getConfig().contains("tables." + worldName)) {
             ConfigurationSection tablesSection = plugin.getConfig().getConfigurationSection("tables." + worldName);
             String key = centerX + "_" + centerY + "_" + centerZ;
             tablesSection.set(key, null);
             plugin.saveConfig();
         }
-        
+
         return true;
     }
-    
+
     /**
-     * Find the nearest table to a player's location
+     * Find the nearest table to a player's location.
+     * Each table is checked against its own max-join-distance setting.
      */
     public BlackjackTable findNearestTable(Location playerLoc) {
-        double maxDistance = configManager.getMaxJoinDistance();
-        double closestDistance = maxDistance;
+        double closestDistance = Double.MAX_VALUE;
         BlackjackTable closestTable = null;
-        
+
         for (Map.Entry<Location, BlackjackTable> entry : tables.entrySet()) {
             Location tableLoc = entry.getKey();
             if (!tableLoc.getWorld().equals(playerLoc.getWorld())) {
                 continue;
             }
-            
+
+            BlackjackTable table = entry.getValue();
             double distance = tableLoc.distance(playerLoc);
-            if (distance < closestDistance) {
+            double tableMaxDist = table.getSettings().getMaxJoinDistance(configManager);
+
+            if (distance <= tableMaxDist && distance < closestDistance) {
                 closestDistance = distance;
-                closestTable = entry.getValue();
+                closestTable = table;
             }
         }
-        
+
         return closestTable;
     }
-    
+
     /**
      * Get the table a player is currently at
      */
     public BlackjackTable getPlayerTable(Player player) {
         return playerTables.get(player);
     }
-    
+
     /**
      * Set which table a player is at
      */
@@ -200,14 +209,14 @@ public class TableManager {
             playerTables.put(player, table);
         }
     }
-    
+
     /**
      * Remove player from any table they're at
      */
     public void removePlayerFromTable(Player player) {
         removePlayerFromTable(player, "left the table");
     }
-    
+
     /**
      * Remove player from any table they're at with custom reason
      */
@@ -217,14 +226,21 @@ public class TableManager {
             table.removePlayer(player, reason);
         }
     }
-    
+
     /**
      * Get all tables
      */
     public Map<Location, BlackjackTable> getAllTables() {
         return tables;
     }
-    
+
+    /**
+     * Persist updated settings for an existing table (used by /bj settable).
+     */
+    public void saveTableSettings(BlackjackTable table) {
+        saveTableToConfig(table.getCenterLocation(), table.getSettings());
+    }
+
     /**
      * Cleanup all tables
      */
@@ -234,5 +250,47 @@ public class TableManager {
         }
         tables.clear();
         playerTables.clear();
+    }
+
+    // -------------------------------------------------------------------------
+    // Config persistence helpers
+    // -------------------------------------------------------------------------
+
+    private String buildTablePath(Location loc) {
+        return "tables." + loc.getWorld().getName() + "."
+                + loc.getBlockX() + "_" + loc.getBlockY() + "_" + loc.getBlockZ();
+    }
+
+    private void saveTableToConfig(Location loc, TableSettings settings) {
+        String path = buildTablePath(loc);
+        if (settings.getRawMinBet() == null && settings.getRawMaxBet() == null
+                && settings.getRawMaxPlayers() == null
+                && settings.getRawMaxJoinDistance() == null) {
+            // No overrides — use compact boolean form
+            plugin.getConfig().set(path, true);
+        } else {
+            // Store sub-keys; null values are omitted (Bukkit skips null sets)
+            plugin.getConfig().set(path + ".min-bet",           settings.getRawMinBet());
+            plugin.getConfig().set(path + ".max-bet",           settings.getRawMaxBet());
+            plugin.getConfig().set(path + ".max-players",       settings.getRawMaxPlayers());
+            plugin.getConfig().set(path + ".max-join-distance", settings.getRawMaxJoinDistance());
+        }
+        plugin.saveConfig();
+    }
+
+    private TableSettings loadSettingsFromConfig(ConfigurationSection worldSection, String locKey) {
+        Object raw = worldSection.get(locKey);
+        if (raw instanceof Boolean) {
+            return new TableSettings(); // Legacy format — all fields use global defaults
+        }
+        ConfigurationSection sec = worldSection.getConfigurationSection(locKey);
+        if (sec == null) {
+            return new TableSettings();
+        }
+        Integer minBet   = sec.contains("min-bet")           ? sec.getInt("min-bet")             : null;
+        Integer maxBet   = sec.contains("max-bet")           ? sec.getInt("max-bet")              : null;
+        Integer maxP     = sec.contains("max-players")       ? sec.getInt("max-players")          : null;
+        Double  maxDist  = sec.contains("max-join-distance") ? sec.getDouble("max-join-distance") : null;
+        return new TableSettings(minBet, maxBet, maxP, maxDist);
     }
 }

--- a/src/main/java/com/vortex/blackjack/table/TableSettings.java
+++ b/src/main/java/com/vortex/blackjack/table/TableSettings.java
@@ -1,0 +1,141 @@
+package com.vortex.blackjack.table;
+
+import com.vortex.blackjack.config.ConfigManager;
+
+/**
+ * Per-table settings overrides. Null fields fall back to the global ConfigManager values.
+ */
+public class TableSettings {
+
+    private Integer minBet;
+    private Integer maxBet;
+    private Integer maxPlayers;
+    private Double  maxJoinDistance;
+
+    /** All-nulls constructor — every field resolves to the global config default. */
+    public TableSettings() {}
+
+    /** Full constructor used when loading persisted settings from config. */
+    public TableSettings(Integer minBet, Integer maxBet,
+                         Integer maxPlayers, Double maxJoinDistance) {
+        this.minBet          = minBet;
+        this.maxBet          = maxBet;
+        this.maxPlayers      = maxPlayers;
+        this.maxJoinDistance = maxJoinDistance;
+    }
+
+    // -------------------------------------------------------------------------
+    // Resolved getters — always return a usable value
+    // -------------------------------------------------------------------------
+
+    public int getMinBet(ConfigManager cfg) {
+        return minBet != null ? minBet : cfg.getMinBet();
+    }
+
+    public int getMaxBet(ConfigManager cfg) {
+        return maxBet != null ? maxBet : cfg.getMaxBet();
+    }
+
+    public int getMaxPlayers(ConfigManager cfg) {
+        return maxPlayers != null ? maxPlayers : cfg.getMaxPlayers();
+    }
+
+    public double getMaxJoinDistance(ConfigManager cfg) {
+        return maxJoinDistance != null ? maxJoinDistance : cfg.getMaxJoinDistance();
+    }
+
+    // -------------------------------------------------------------------------
+    // Raw nullable getters (for serialisation — null means "not set")
+    // -------------------------------------------------------------------------
+
+    public Integer getRawMinBet()          { return minBet; }
+    public Integer getRawMaxBet()          { return maxBet; }
+    public Integer getRawMaxPlayers()      { return maxPlayers; }
+    public Double  getRawMaxJoinDistance() { return maxJoinDistance; }
+
+    // -------------------------------------------------------------------------
+    // Setters (used by /bj settable)
+    // -------------------------------------------------------------------------
+
+    public void setMinBet(Integer v)         { this.minBet          = v; }
+    public void setMaxBet(Integer v)         { this.maxBet          = v; }
+    public void setMaxPlayers(Integer v)     { this.maxPlayers      = v; }
+    public void setMaxJoinDistance(Double v) { this.maxJoinDistance = v; }
+
+    // -------------------------------------------------------------------------
+    // Validation
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns an error description if the current settings are invalid, or null if OK.
+     */
+    public String validate(ConfigManager cfg) {
+        int lo = getMinBet(cfg);
+        int hi = getMaxBet(cfg);
+        if (lo > hi) return "min-bet (" + lo + ") cannot exceed max-bet (" + hi + ")";
+        if (maxPlayers != null && (maxPlayers < 1 || maxPlayers > 8))
+            return "max-players must be between 1 and 8";
+        if (maxJoinDistance != null && maxJoinDistance < 1.0)
+            return "max-join-distance must be at least 1";
+        return null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Parsing
+    // -------------------------------------------------------------------------
+
+    /**
+     * Parses named-argument tokens of the form "key:value" starting at {@code startIndex}.
+     * Recognised keys: min-bet, max-bet, max-players, max-join-distance.
+     * On error writes a description into {@code errorOut} and returns null.
+     */
+    public static TableSettings parseArgs(String[] tokens, int startIndex,
+                                          ConfigManager cfg, StringBuilder errorOut) {
+        TableSettings s = new TableSettings();
+        for (int i = startIndex; i < tokens.length; i++) {
+            String tok   = tokens[i];
+            int    colon = tok.indexOf(':');
+            if (colon < 0) {
+                errorOut.append("Invalid argument '").append(tok)
+                        .append("' — expected format key:value");
+                return null;
+            }
+            String key = tok.substring(0, colon).toLowerCase();
+            String val = tok.substring(colon + 1);
+            try {
+                switch (key) {
+                    case "min-bet"            -> s.setMinBet(parsePositiveInt(val));
+                    case "max-bet"            -> s.setMaxBet(parsePositiveInt(val));
+                    case "max-players"        -> s.setMaxPlayers(parsePositiveInt(val));
+                    case "max-join-distance"  -> s.setMaxJoinDistance(parsePositiveDouble(val));
+                    default -> {
+                        errorOut.append("Unknown setting '").append(key)
+                                .append("'. Valid: min-bet, max-bet, max-players, max-join-distance");
+                        return null;
+                    }
+                }
+            } catch (NumberFormatException e) {
+                errorOut.append("Invalid value for '").append(key).append("': ").append(val);
+                return null;
+            }
+        }
+        String err = s.validate(cfg);
+        if (err != null) {
+            errorOut.append(err);
+            return null;
+        }
+        return s;
+    }
+
+    private static int parsePositiveInt(String s) {
+        int v = Integer.parseInt(s);
+        if (v <= 0) throw new NumberFormatException("must be positive");
+        return v;
+    }
+
+    private static double parsePositiveDouble(String s) {
+        double v = Double.parseDouble(s);
+        if (v <= 0) throw new NumberFormatException("must be positive");
+        return v;
+    }
+}

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -10,10 +10,17 @@ player-only-command: "&cThis command can only be used by players!"
 
 # Table management
 table-created: "&aBlackjack table created!"
+table-created-with-settings: "&aTable created! &7(min: &e%min_bet%&7, max: &e%max_bet%&7, players: &e%max_players%&7, distance: &e%max_join_distance%&7)"
+createtable-invalid-arg: "&cInvalid argument: %error%"
 table-removed: "&cBlackjack table removed!"
 table-already-exists: "&cTable already exists at this location!"
 table-remove-failed: "&cFailed to remove table!"
 no-table-nearby: "&cNo table found nearby!"
+settable-usage: "&eUsage: /bj settable <setting> <value>"
+settable-unknown-setting: "&cUnknown setting '%setting%'. Valid: min-bet, max-bet, max-players, max-join-distance"
+settable-invalid-value: "&cInvalid value: '%value%'"
+settable-validation-error: "&cValidation failed: %error%"
+settable-updated: "&aSetting &e%setting% &aset to &e%value% &aon nearest table."
 
 # Player table status
 already-at-table: "&cYou are already at a table! Use /leave to leave your current table."
@@ -105,7 +112,8 @@ config-reloaded: "&aConfiguration reloaded!"
 
 # Help command
 help-header: "&rAvailable Commands:"
-help-admin-create: "&e/bj createtable &7- Create a new blackjack table"
+help-admin-create: "&e/bj createtable [min-bet:<n>] [max-bet:<n>] [max-players:<n>] [max-join-distance:<n>] &7- Create a table"
+help-admin-settable: "&e/bj settable <setting> <value> &7- Modify nearest table settings"
 help-admin-remove: "&e/bj removetable &7- Remove the nearest table"
 help-admin-reload: "&e/bj reload &7- Reload configuration"
 help-join: "&e/join &7- Join the nearest table"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -13,7 +13,8 @@ commands:
     description: Main command for the Blackjack plugin
     usage: |
       &8[&6Blackjack&8] &rAvailable Commands:
-      &e/createtable &7- Create a new blackjack table
+      &e/createtable [min-bet:<n>] [max-bet:<n>] [max-players:<n>] [max-join-distance:<n>] &7- Create a table
+      &e/settable <setting> <value> &7- Modify nearest table settings
       &e/removetable &7- Remove the nearest table
       &e/join &7- Join the nearest table
       &e/leave &7- Leave your current table
@@ -27,6 +28,11 @@ commands:
   createtable:
     description: Create a new blackjack table
     permission: blackjack.admin
+    usage: /createtable [min-bet:<n>] [max-bet:<n>] [max-players:<n>] [max-join-distance:<n>]
+  settable:
+    description: Modify settings on the nearest blackjack table
+    permission: blackjack.admin
+    usage: /settable <min-bet|max-bet|max-players|max-join-distance> <value>
   removetable:
     description: Remove the nearest blackjack table
     permission: blackjack.admin


### PR DESCRIPTION
Allow admins to configure min/max bet, max players, and departure distance individually per table at creation time or after the fact.

- New TableSettings class with nullable overrides (null = global default)
- /createtable now accepts optional named args: min-bet:<n>, max-bet:<n>, max-players:<n>, max-join-distance:<n>
- New /settable command to modify settings on the nearest table
- Tab completion for both commands (setting keys + current value hints)
- Settings persisted per-table in config.yml; backward-compatible with existing tables stored as 'true'
- Per-table limits applied to bet validation and auto-leave distance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/bj createtable` command with optional arguments to configure minimum bet, maximum bet, maximum players, and maximum join distance when creating tables.
  * Added `/bj settable` command to modify settings on the nearest blackjack table.
  * Per-table settings now supported, allowing individual tables to have custom configurations independent of global defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->